### PR TITLE
improve error handling on start and wait of the container

### DIFF
--- a/src/containerHelpers.js
+++ b/src/containerHelpers.js
@@ -1,24 +1,49 @@
-export async function startAndWaitForPort(container, portToAwait) {
-  if (!container.running) {
-    container.start();
-  }
-
+export async function startAndWaitForPort(
+  container,
+  portToAwait,
+  maxTries = 10,
+) {
   const port = container.getTcpPort(portToAwait);
-  for (let i = 0; i < 1000; i++) {
+  // promise to make sure the container does not exit
+  let monitor;
+
+  for (let i = 0; i < maxTries; i++) {
     try {
-      await port.fetch("http://10.0.0.1/");
-      await new Promise((res) => setTimeout(res, 300));
+      if (!container.running) {
+        container.start();
+
+        // force DO to keep track of running state
+        monitor = container.monitor();
+      }
+
+      const conn = await port.connect(`10.0.0.1:${portToAwait}`);
+      conn.close();
       break;
     } catch (err) {
-      console.error(err);
+      console.error("Error connecting to the container on", i, "try", err);
+
       if (err.message.includes("listening")) {
-        await new Promise((res) => setTimeout(res, 100));
+        await new Promise((res) => setTimeout(res, 300));
+        continue;
+      }
+
+      // no container yet
+      if (
+        err.message.includes(
+          "there is no container instance that can be provided",
+        )
+      ) {
+        await new Promise((res) => setTimeout(res, 300));
         continue;
       }
 
       throw err;
     }
   }
+
+  throw new Error(
+    `could not check container healthiness after ${maxTries} tries`,
+  );
 }
 
 export async function proxyFetch(container, request, portNumber) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const OPEN_CONTAINER_PORT = 8080;
 const LB_INSTANCES = 3;
 
 export default {
-  async fetch(request, env, ctx) {
+  async fetch(request, env) {
     const pathname = new URL(request.url).pathname;
 
     // If you wish to route requests to a specific container,


### PR DESCRIPTION
If the container platform cannot provision the instance, the start() will fail, which is a retriable error for the user.

At the end of the loop, if no success has happened, we need to throw an error, so the DO triggers again the constructor if we haven't been successful initialising the `container` property.